### PR TITLE
Add ability to handle schemas with interdependencies

### DIFF
--- a/src/file_parser.rs
+++ b/src/file_parser.rs
@@ -4,17 +4,8 @@ use apache_avro::Schema;
 
 pub fn parse_schemas(files: Vec<AvroFile>) -> Result<Vec<Schema>> 
 {
-    let mut schema_list = Vec::<Schema>::new();
+    let schema_content_list: Vec<&str> = files.iter().map(|f| f.content.as_str()).collect();
+    Schema::parse_list(&schema_content_list)
+        .map_err(|e| { AvrogenError::Custom(format!("{:?}",e)) })
 
-    for file in files {
-
-        let schema = Schema::parse_str(&file.content)
-        .map_err(|e| AvrogenError::Custom(format!("{:?}: {e}",file.file_path)))?;
-        
-        log::debug!("schema {} read",file.file_path);
-
-        schema_list.push(schema)
-    }
-
-    Ok(schema_list)
 }

--- a/test_schemas/type_by_reference/expected_flat/mod.rs
+++ b/test_schemas/type_by_reference/expected_flat/mod.rs
@@ -1,0 +1,23 @@
+pub mod com {
+
+    pub mod example {
+
+        #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, Default)]
+        #[serde(default)]
+        pub struct A {
+            pub some_int: i32,
+            pub some_string: String,
+        }
+
+        impl A {}
+
+        #[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, Default)]
+        #[serde(default)]
+        pub struct B {
+            pub some_a: crate::com::example::A,
+        }
+
+        impl B {}
+
+    }
+}

--- a/test_schemas/type_by_reference/expected_structured/com.rs
+++ b/test_schemas/type_by_reference/expected_structured/com.rs
@@ -1,0 +1,2 @@
+pub mod example;
+

--- a/test_schemas/type_by_reference/expected_structured/com/example.rs
+++ b/test_schemas/type_by_reference/expected_structured/com/example.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, Default)]
+#[serde(default)]
+pub struct A {
+    pub some_int: i32,
+    pub some_string: String,
+}
+
+impl A {}
+
+#[derive(Debug, PartialEq, Clone, serde::Deserialize, serde::Serialize, Default)]
+#[serde(default)]
+pub struct B {
+    pub some_a: crate::com::example::A,
+}
+
+impl B {}
+

--- a/test_schemas/type_by_reference/schema_a.avsc
+++ b/test_schemas/type_by_reference/schema_a.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "com.example",
+  "name": "A",
+  "type": "record",
+  "fields": [
+    { "name":  "some_int", "type": "int" },
+    { "name":  "some_string", "type": "string" }
+  ]
+}

--- a/test_schemas/type_by_reference/schema_b.avsc
+++ b/test_schemas/type_by_reference/schema_b.avsc
@@ -1,0 +1,8 @@
+{
+  "namespace": "com.example",
+  "type": "record",
+  "name": "B",
+  "fields": [
+    { "name":  "some_a", "type": "A" }
+  ]
+}

--- a/tests/enum_test.rs
+++ b/tests/enum_test.rs
@@ -58,3 +58,34 @@ fn convert_recursive_record() {
 fn convert_recursive_record_flat() {
     standard_flat_test("recursive_record");
 }
+
+#[test]
+fn convert_type_with_reference() {
+    let dest_folder = "target/tmp/.result/type_by_reference/";
+    let expected_folder = "test_schemas/type_by_reference/expected_structured/";
+
+    Avrogen::new()
+        .add_source("test_schemas/type_by_reference/*.avsc")
+        .output_folder_from_str(dest_folder)
+        .set_verbosity_debug()
+        .execute()
+        .expect("No error should appear");
+
+    compare_folders_content(dest_folder, expected_folder);
+}
+
+#[test]
+fn convert_type_with_reference_flat() {
+    let dest_folder = "target/tmp/.result/type_by_reference_flat/";
+    let expected_folder = "test_schemas/type_by_reference/expected_flat/";
+
+    Avrogen::new()
+        .add_source("test_schemas/type_by_reference/*.avsc")
+        .output_folder_from_str(dest_folder)
+        .set_verbosity_debug()
+        .set_flat_output()
+        .execute()
+        .expect("No error should appear");
+
+    compare_folders_content(dest_folder, expected_folder);
+}


### PR DESCRIPTION
Adds the ability for avrogen to handle a directory of schemas which might have interdependencies.

For instance, say you have a record schema called A, and you have a record schema called B (in a separate file) which has a field of type A.  With this patch, the schemas can be parsed correctly and code generation will succeed.